### PR TITLE
Docker CRAN Setting issue - follow up PR

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM jhudsl/course_template
 LABEL maintainer="cwright60@jhu.edu"
 
-# Commonly used R packages
-RUN Rscript -e  "devtools::install_version('OCSdata', repos = 'http://cran.us.r-project.org')"
+# OCSData install
+RUN R -e "options(warn = 2); install.packages(c('OCSdata'), \
+  repos = 'https://cloud.r-project.org/')"


### PR DESCRIPTION
This is a parallel PR to: https://github.com/jhudsl/OTTR_Template/pull/446 which says:

> ### Purpose/implementation Section
> #### What changes are being implemented in this Pull Request?
> This is related to [#432](https://github.com/jhudsl/OTTR_Template/issues/432)
> 
> There are two things needed to get around this problem that are added here to the TEMPLATE_Dockerfile as well as the Dockerfile itself.
> 
>   1. `options(warn= 2)` makes sure that if the package isn't found or doesn't install the docker build fails.
>   2. ` repos = 'https://cloud.r-project.org/'` specfies the CRAN so we make sure we're pulling from an updated one.
> 
> I tested this by building an image with the `OCSdata` package installed this way and started a container with that built image and it did indeed install `OCSdata`.
